### PR TITLE
Fix picture redimensioning

### DIFF
--- a/bioprinter/bioprinter.py
+++ b/bioprinter/bioprinter.py
@@ -112,7 +112,7 @@ def bioprint(
     resolution_ratio = 1.0 * resolution_w / resolution_h
 
     image = Image.open(image_filename)
-    height, width = image.size
+    width, height = image.size
 
     # IF THE PICTURE IS HIGHER THAN WIDE, CHANGE THE ORIENTATION
 
@@ -125,10 +125,10 @@ def bioprint(
     image_ratio = 1.0 * width / height
     if (height > resolution_h) or (width > resolution_w):
         if image_ratio > resolution_ratio:
-            new_size = (int(resolution_w / image_ratio), resolution_w)
+            new_size = (resolution_w, int(resolution_w / image_ratio))
             image = image.resize(new_size)
         else:
-            new_size = (resolution_h, int(resolution_h * image_ratio))
+            new_size = (int(resolution_h * image_ratio), resolution_h)
             image = image.resize(image, new_size)
     image = np.array(image)
 

--- a/bioprinter/bioprinter.py
+++ b/bioprinter/bioprinter.py
@@ -125,11 +125,12 @@ def bioprint(
     image_ratio = 1.0 * width / height
     if (height > resolution_h) or (width > resolution_w):
         if image_ratio > resolution_ratio:
-            new_size = (resolution_w, int(resolution_w / image_ratio))
-            image = image.resize(new_size)
+            new_width = resolution_w
+            new_height = int(np.round(resolution_w / image_ratio))
         else:
-            new_size = (int(resolution_h * image_ratio), resolution_h)
-            image = image.resize(image, new_size)
+            new_width = int(np.round(resolution_h * image_ratio))
+            new_height = resolution_h
+        image = image.resize((new_width, new_height))
     image = np.array(image)
 
     # QUANTIFY THE ORIGINAL IMAGE WITH THE PROVIDED PIGMENTS COLORS

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
-import unittest
+from PIL import Image
+
 
 from bioprinter import bioprint
 
@@ -24,3 +25,8 @@ def test_basics():
     )
     assert os.path.exists(quantified_image_filename)
     assert os.path.exists(output_filename)
+    assert Image.open(quantified_image_filename).size == (192, 127)
+
+    
+
+

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -26,7 +26,3 @@ def test_basics():
     assert os.path.exists(quantified_image_filename)
     assert os.path.exists(output_filename)
     assert Image.open(quantified_image_filename).size == (192, 127)
-
-    
-
-


### PR DESCRIPTION
Hey! I tried reusing this recently and realized it has a bug in picture re-dimensioning - it is using a (height, width) tuple while it should be (width, height). Either the PIL API changed or something got lost going from a scipy-based to a PIL-based API.

This PR fixes this and add a minimal test to check that the redimensioned picture has the right orientation. More tests would be needed to catch all cases but I'm a bit short on time.